### PR TITLE
Removed phpunit as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
         }
     ],
     "require": {
-        "jolicode/jolinotif": "~1.0",
-        "phpunit/phpunit": "~4.5"
+        "jolicode/jolinotif": "~1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
You don't really need it (and less again with 4.5 ; >3 should be ok)
I work well with a global phpunit installed
